### PR TITLE
fix: `lodash` import breaking build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,3 @@
 node_modules/
 .svelte-kit/
-
-public/bundle.js
-public/app.js
-public/confMat.js
-public/third_party/
+build/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
               uses: actions/setup-node@v3
             - name: Install Node dependencies
               run: yarn --frozen-lockfile
-            - run: yarn test:unit
-            - run: yarn lint
-            - run: yarn fmt
+            - name: Build
+              run: yarn build
+            - name: Test
+              run: yarn test:unit
+            - name: Lint
+              run: yarn lint
+            - name: Check formatting
+              run: yarn fmt

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@apple/hierarchical-confusion-matrix",
     "author": "Apple Inc.",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": "SEE LICENSE IN `LICENSE`",
     "main": "package/confMat.js",
     "files": [

--- a/src/lib/confusions.ts
+++ b/src/lib/confusions.ts
@@ -6,7 +6,7 @@
 
 import type { Condition, Spec } from './specification';
 import { rollup, sum } from 'd3-array';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash';
 import type { Entry } from './matrix';
 import { Matrix } from './matrix';
 import ndarray from 'ndarray';

--- a/src/lib/confusions.ts
+++ b/src/lib/confusions.ts
@@ -6,7 +6,7 @@
 
 import type { Condition, Spec } from './specification';
 import { rollup, sum } from 'd3-array';
-import cloneDeep from 'lodash';
+import lodash from 'lodash';
 import type { Entry } from './matrix';
 import { Matrix } from './matrix';
 import ndarray from 'ndarray';
@@ -213,7 +213,7 @@ export function addRangeIndex(root: Entry): Entry {
 }
 
 export function buildMatrix(spec: Spec, confusions: Array<Confusion>): Matrix {
-    let cloned = cloneDeep(confusions);
+    let cloned = lodash.cloneDeep(confusions);
     addMissingLabels(cloned);
 
     // Condition

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@ Copyright (C) 2022 Apple Inc. All Rights Reserved.
 -->
 
 <script lang="ts">
-    import cloneDeep from 'lodash';
+    import lodash from 'lodash';
     import MatrixWithUI from '../lib/components/MatrixWithUI.svelte';
     import { spec } from '../lib/components/stores';
     import { version } from '$app/environment';
@@ -18,7 +18,7 @@ Copyright (C) 2022 Apple Inc. All Rights Reserved.
     let specVisible = false;
 
     // We always want to start with a fresh slate
-    $: $spec = cloneDeep(example.spec);
+    $: $spec = lodash.cloneDeep(example.spec);
 
     $: confusionPromise = example.loader(example.filename);
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@ Copyright (C) 2022 Apple Inc. All Rights Reserved.
 -->
 
 <script lang="ts">
-    import { cloneDeep } from 'lodash';
+    import cloneDeep from 'lodash';
     import MatrixWithUI from '../lib/components/MatrixWithUI.svelte';
     import { spec } from '../lib/components/stores';
     import { version } from '$app/environment';


### PR DESCRIPTION
When building, I get an error: 

```
import { cloneDeep } from "lodash";
         ^^^^^^^^^
SyntaxError: Named export 'cloneDeep' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'lodash';
const { cloneDeep } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:128:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:194:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:409:24)
    at async analyse (file:///Users/fredhohman/Github/apple/ml-hierarchical-confusion-matrix/node_modules/@sveltejs/kit/src/core/postbuild/analyse.js:59:16)
    at async process.<anonymous> (file:///Users/fredhohman/Github/apple/ml-hierarchical-confusion-matrix/node_modules/@sveltejs/kit/src/utils/fork.js:25:17)
```

Looks like it's a JS important issue. I made a suggested fix and it builds successfully. But then running the visualization gives a console error: 

<img width="857" alt="image" src="https://github.com/apple/ml-hierarchical-confusion-matrix/assets/5741691/8acc3cda-356a-49ca-800b-73714779c592">

@grtlr are you able to reproduce?